### PR TITLE
CI: Upgrade clang-format-check action v3.3.0 -> v4.11.0

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -62,7 +62,7 @@ jobs:
       shell: bash
 
     - name: Check code formatting
-      uses: jidicula/clang-format-action@v3.3.0
+      uses: jidicula/clang-format-action@v4.11.0
       with:
           clang-format-version: '10'
           check-path: '.'


### PR DESCRIPTION
Previous CI configuration fails

```
Installing clang-format-10
Ign:1 http://archive.ubuntu.com/ubuntu groovy InRelease
Ign:2 http://archive.ubuntu.com/ubuntu groovy-updates InRelease
Ign:3 http://archive.ubuntu.com/ubuntu groovy-backports InRelease
Err:4 http://archive.ubuntu.com/ubuntu groovy Release
  404  Not Found [IP: 91.189.91.83 80]
Err:5 http://archive.ubuntu.com/ubuntu groovy-updates Release
  404  Not Found [IP: 91.189.91.83 80]
Err:6 http://archive.ubuntu.com/ubuntu groovy-backports Release
  404  Not Found [IP: 91.189.91.83 80]
Ign:7 http://security.ubuntu.com/ubuntu groovy-security InRelease
Err:8 http://security.ubuntu.com/ubuntu groovy-security Release
  404  Not Found [IP: 185.125.190.39 80]
Reading package lists...
E: The repository 'http://archive.ubuntu.com/ubuntu groovy Release' does not have a Release file.
E: The repository 'http://archive.ubuntu.com/ubuntu groovy-updates Release' does not have a Release file.
E: The repository 'http://archive.ubuntu.com/ubuntu groovy-backports Release' does not have a Release file.
E: The repository 'http://security.ubuntu.com/ubuntu groovy-security Release' does not have a Release file.
/entrypoint.sh: line 22: /usr/bin/clang-format-10: No such file or directory
```